### PR TITLE
Target Go 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/alberto255345/dbfmini
 
-go 1.23
+go 1.22
 
 require golang.org/x/text v0.18.0


### PR DESCRIPTION
## Summary
- downgrade the module go directive to Go 1.22 to use an available toolchain

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68c9c726eda0832fa717feb23b506b02